### PR TITLE
Resize stateful sets to 64Gi.

### DIFF
--- a/k8s/base/juno/statefulset.yaml
+++ b/k8s/base/juno/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 24Gi
+            storage: 64Gi
 
 ---
 apiVersion: v1

--- a/k8s/base/madara/statefulset.yaml
+++ b/k8s/base/madara/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 24Gi
+            storage: 64Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/papyrus/statefulset.yaml
+++ b/k8s/base/papyrus/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 24Gi
+            storage: 64Gi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/pathfinder/statefulset.yaml
+++ b/k8s/base/pathfinder/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 24Gi
+            storage: 64Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
	- Increased persistent storage capacity from 24Gi to 64Gi for multiple services:
		- Juno
		- Madara
		- Papyrus
		- Pathfinder

This update provides significantly more storage space for these Kubernetes-deployed applications, ensuring they have sufficient persistent volume capacity for their operational needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->