### PR TITLE
232 add starknet specversion test

### DIFF
--- a/openrpc-testgen/src/suite_openrpc/mod.rs
+++ b/openrpc-testgen/src/suite_openrpc/mod.rs
@@ -59,7 +59,8 @@ pub mod test_get_txn_by_block_id_and_index_declare_v3;
 pub mod test_get_txn_by_block_id_and_index_deploy_account_v1;
 pub mod test_get_txn_by_block_id_and_index_deploy_account_v3;
 pub mod test_spec_version;
-// pub mod test_syncing;
+pub mod test_syncing;
+
 #[derive(Clone, Debug)]
 pub struct TestSuiteOpenRpc {
     pub random_paymaster_account: RandomSingleOwnerAccount,

--- a/openrpc-testgen/src/suite_openrpc/mod.rs
+++ b/openrpc-testgen/src/suite_openrpc/mod.rs
@@ -58,7 +58,8 @@ pub mod test_get_txn_by_block_id_and_index_declare_v2;
 pub mod test_get_txn_by_block_id_and_index_declare_v3;
 pub mod test_get_txn_by_block_id_and_index_deploy_account_v1;
 pub mod test_get_txn_by_block_id_and_index_deploy_account_v3;
-pub mod test_syncing;
+pub mod test_spec_version;
+// pub mod test_syncing;
 #[derive(Clone, Debug)]
 pub struct TestSuiteOpenRpc {
     pub random_paymaster_account: RandomSingleOwnerAccount,

--- a/openrpc-testgen/src/suite_openrpc/test_spec_version.rs
+++ b/openrpc-testgen/src/suite_openrpc/test_spec_version.rs
@@ -7,6 +7,9 @@ use crate::{
     RunnableTrait,
 };
 
+/// These tests check node compatibility with spec version 0.7.1
+const EXPECTED_SPEC_VERSION: &str = "0.7.1";
+
 #[derive(Clone, Debug)]
 pub struct TestCase {}
 
@@ -26,13 +29,11 @@ impl RunnableTrait for TestCase {
 
         let spec_version = spec_version?;
 
-        let expected_spec_version = "0.7.1".to_string();
-
         assert_result!(
-            spec_version == expected_spec_version,
+            spec_version == EXPECTED_SPEC_VERSION,
             format!(
                 "Expected spec version to be {}, but got {}",
-                expected_spec_version, spec_version
+                EXPECTED_SPEC_VERSION, spec_version
             )
         );
 

--- a/openrpc-testgen/src/suite_openrpc/test_spec_version.rs
+++ b/openrpc-testgen/src/suite_openrpc/test_spec_version.rs
@@ -1,0 +1,41 @@
+use crate::{
+    assert_result,
+    utils::v7::{
+        accounts::account::ConnectedAccount, endpoints::errors::OpenRpcTestGenError,
+        providers::provider::Provider,
+    },
+    RunnableTrait,
+};
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteOpenRpc;
+
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let spec_version = test_input
+            .random_paymaster_account
+            .provider()
+            .spec_version()
+            .await;
+
+        let result = spec_version.is_ok();
+
+        assert_result!(result);
+
+        let spec_version = spec_version?;
+
+        let expected_spec_version = "0.7.1".to_string();
+
+        assert_result!(
+            spec_version == expected_spec_version,
+            format!(
+                "Expected spec version to be {}, but got {}",
+                expected_spec_version, spec_version
+            )
+        );
+
+        Ok(Self {})
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for test specifications.
	- Added a new test case to verify the OpenRPC specification version.
	- Implemented a test to check the specification version against the expected value "0.7.1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->