### PR TITLE
Add estimate fee tests.

### DIFF
--- a/openrpc-testgen/src/suite_openrpc/mod.rs
+++ b/openrpc-testgen/src/suite_openrpc/mod.rs
@@ -40,6 +40,8 @@ pub mod test_declare_txn_v2;
 pub mod test_declare_txn_v3;
 pub mod test_deploy_account_outside_execution;
 pub mod test_erc20_transfer_outside_execution;
+pub mod test_estimate_fee_fri;
+pub mod test_estimate_fee_wei;
 pub mod test_get_block_number;
 pub mod test_get_block_txn_count;
 pub mod test_get_block_with_tx_hashes;

--- a/openrpc-testgen/src/suite_openrpc/suite_deploy/suite_contract_calls/test_get_storage_at.rs
+++ b/openrpc-testgen/src/suite_openrpc/suite_deploy/suite_contract_calls/test_get_storage_at.rs
@@ -50,8 +50,6 @@ impl RunnableTrait for TestCase {
             )
             .await?;
 
-        println!("Initial storage value: {:?}", initial_storage_value);
-
         // Step 3: Update the storage value
         let balance_increase = Felt::from_hex("0x50")?;
         let increase_balance_call = Call {

--- a/openrpc-testgen/src/suite_openrpc/test_estimate_fee_fri.rs
+++ b/openrpc-testgen/src/suite_openrpc/test_estimate_fee_fri.rs
@@ -1,0 +1,82 @@
+use std::{path::PathBuf, str::FromStr};
+
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::PriceUnit;
+
+use crate::{
+    assert_result,
+    utils::v7::{
+        accounts::account::Account,
+        endpoints::{declare_contract::get_compiled_contract, errors::OpenRpcTestGenError},
+    },
+    RunnableTrait,
+};
+
+const STRK_BLOB_GAS_PRICE: Felt = Felt::from_hex_unchecked("0x14");
+const STRK_GAS_PRICE: Felt = Felt::from_hex_unchecked("0xa");
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteOpenRpc;
+
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let (flattened_sierra_class, compiled_class_hash) = get_compiled_contract(
+            PathBuf::from_str(
+                "target/dev/contracts_contracts_smpl14_HelloStarknet.contract_class.json",
+            )?,
+            PathBuf::from_str(
+                "target/dev/contracts_contracts_smpl14_HelloStarknet.compiled_contract_class.json",
+            )?,
+        )
+        .await?;
+
+        let estimate_fee = test_input
+            .random_paymaster_account
+            .declare_v3(flattened_sierra_class.clone(), compiled_class_hash)
+            .estimate_fee()
+            .await?;
+
+        assert_result!(
+            estimate_fee.unit == PriceUnit::Fri,
+            format!(
+                "Estimate fee unit expected: {:?}, actual: {:?}",
+                PriceUnit::Fri,
+                estimate_fee.unit
+            )
+        );
+
+        assert_result!(
+            estimate_fee.gas_price == STRK_GAS_PRICE,
+            format!(
+                "Estimate fee gas price expected: {:?}, actual: {:?}",
+                STRK_GAS_PRICE, estimate_fee.gas_price
+            )
+        );
+
+        assert_result!(
+            estimate_fee.data_gas_price == STRK_BLOB_GAS_PRICE,
+            format!(
+                "Estimate fee data gas price expected: {:?}, actual: {:?}",
+                STRK_BLOB_GAS_PRICE, estimate_fee.data_gas_price
+            )
+        );
+
+        let data_fee = estimate_fee.data_gas_consumed * estimate_fee.data_gas_price;
+
+        let fee = estimate_fee.gas_consumed * estimate_fee.gas_price;
+
+        let overall_fee = data_fee + fee;
+
+        assert_result!(
+            overall_fee == estimate_fee.overall_fee,
+            format!(
+                "Estimate fee overall fee expected: {:?}, actual: {:?}",
+                overall_fee, estimate_fee.overall_fee
+            )
+        );
+
+        Ok(Self {})
+    }
+}

--- a/openrpc-testgen/src/suite_openrpc/test_estimate_fee_wei.rs
+++ b/openrpc-testgen/src/suite_openrpc/test_estimate_fee_wei.rs
@@ -1,0 +1,82 @@
+use std::{path::PathBuf, str::FromStr, sync::Arc};
+
+use starknet_types_core::felt::Felt;
+use starknet_types_rpc::PriceUnit;
+
+use crate::{
+    assert_result,
+    utils::v7::{
+        accounts::account::Account,
+        endpoints::{declare_contract::get_compiled_contract, errors::OpenRpcTestGenError},
+    },
+    RunnableTrait,
+};
+
+const BLOB_GAS_PRICE: Felt = Felt::from_hex_unchecked("0x28");
+const GAS_PRICE: Felt = Felt::from_hex_unchecked("0x1e");
+
+#[derive(Clone, Debug)]
+pub struct TestCase {}
+
+impl RunnableTrait for TestCase {
+    type Input = super::TestSuiteOpenRpc;
+
+    async fn run(test_input: &Self::Input) -> Result<Self, OpenRpcTestGenError> {
+        let (flattened_sierra_class, compiled_class_hash) = get_compiled_contract(
+            PathBuf::from_str(
+                "target/dev/contracts_contracts_smpl14_HelloStarknet.contract_class.json",
+            )?,
+            PathBuf::from_str(
+                "target/dev/contracts_contracts_smpl14_HelloStarknet.compiled_contract_class.json",
+            )?,
+        )
+        .await?;
+
+        let estimate_fee = test_input
+            .random_paymaster_account
+            .declare_v2(Arc::new(flattened_sierra_class), compiled_class_hash)
+            .estimate_fee()
+            .await?;
+
+        assert_result!(
+            estimate_fee.unit == PriceUnit::Wei,
+            format!(
+                "Estimate fee unit expected: {:?}, actual: {:?}",
+                PriceUnit::Wei,
+                estimate_fee.unit
+            )
+        );
+
+        assert_result!(
+            estimate_fee.gas_price == GAS_PRICE,
+            format!(
+                "Estimate fee gas price expected: {:?}, actual: {:?}",
+                GAS_PRICE, estimate_fee.gas_price
+            )
+        );
+
+        assert_result!(
+            estimate_fee.data_gas_price == BLOB_GAS_PRICE,
+            format!(
+                "Estimate fee data gas price expected: {:?}, actual: {:?}",
+                BLOB_GAS_PRICE, estimate_fee.data_gas_price
+            )
+        );
+
+        let data_fee = estimate_fee.data_gas_consumed * estimate_fee.data_gas_price;
+
+        let fee = estimate_fee.gas_consumed * estimate_fee.gas_price;
+
+        let overall_fee = data_fee + fee;
+
+        assert_result!(
+            overall_fee == estimate_fee.overall_fee,
+            format!(
+                "Estimate fee overall fee expected: {:?}, actual: {:?}",
+                overall_fee, estimate_fee.overall_fee
+            )
+        );
+
+        Ok(Self {})
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added two new test modules for fee estimation in different units (FRI and Wei)
  - Expanded test coverage for contract deployment and fee estimation processes

- **Bug Fixes**
  - Removed unnecessary debug print statement in storage retrieval test

- **Tests**
  - Implemented comprehensive test cases for StarkNet contract fee estimation
  - Added validation checks for gas prices and fee calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->