### PR TITLE
Feat getter for raw transaction from prepared

### DIFF
--- a/openrpc-testgen/src/utils/v7/accounts/account/declaration.rs
+++ b/openrpc-testgen/src/utils/v7/accounts/account/declaration.rs
@@ -783,6 +783,10 @@ where
             sender_address: self.account.address(),
         })
     }
+
+    pub async fn get_raw_execution(&self) -> &RawDeclarationV2 {
+        &self.inner
+    }
 }
 
 impl<'a, A> PreparedDeclarationV3<'a, A>
@@ -868,5 +872,9 @@ where
             nonce_data_availability_mode: DaMode::L1,
             fee_data_availability_mode: DaMode::L1,
         })
+    }
+
+    pub async fn get_raw_execution(&self) -> &RawDeclarationV3 {
+        &self.inner
     }
 }

--- a/openrpc-testgen/src/utils/v7/accounts/account/execution.rs
+++ b/openrpc-testgen/src/utils/v7/accounts/account/execution.rs
@@ -811,6 +811,10 @@ where
             calldata: self.account.encode_calls(&self.inner.calls),
         })
     }
+
+    pub async fn get_raw_execution(&self) -> &RawExecutionV1 {
+        &self.inner
+    }
 }
 
 impl<'a, A> PreparedExecutionV3<'a, A>
@@ -937,5 +941,9 @@ where
             nonce_data_availability_mode: DaMode::L1,
             fee_data_availability_mode: DaMode::L1,
         })
+    }
+
+    pub async fn get_raw_execution(&self) -> &RawExecutionV3 {
+        &self.inner
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `get_raw_execution()` method for `PreparedDeclarationV2` and `PreparedDeclarationV3`
	- Added `get_raw_execution()` method for `PreparedExecutionV1` and `PreparedExecutionV3`

These new methods provide direct access to raw execution data within prepared declaration and execution structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->